### PR TITLE
use texelFetch in blur shaders

### DIFF
--- a/data/shaders/horizontal_blur.frag
+++ b/data/shaders/horizontal_blur.frag
@@ -2,7 +2,6 @@
 
 uniform sampler2D ssao;
 uniform sampler2D normal_depth;
-uniform vec2 texelSize;
 
 layout (location = 0) out float fragColor;
 

--- a/data/shaders/vertical_blur.frag
+++ b/data/shaders/vertical_blur.frag
@@ -4,7 +4,6 @@ uniform sampler2D horizontalBlur;
 uniform sampler2D normal_depth;
 uniform sampler2D color;
 uniform float farPlane;
-uniform vec2 texelSize;
 
 layout (location = 0) out vec3 fragColor;
 

--- a/source/rendering/world/postprocessing/SSAOPass.cpp
+++ b/source/rendering/world/postprocessing/SSAOPass.cpp
@@ -115,9 +115,6 @@ void SSAOPass::initializeNoise()
 void SSAOPass::resize(int width, int height)
 {
     m_ssaoPass.setUniform("noiseScale", glm::vec2(width, height) / glm::vec2(s_noiseSize));
-    
-    m_horizontalBlurPass.setUniform("texelSize", 1.0f / glm::vec2(width, height));
-    m_verticalBlurPass.setUniform("texelSize", 1.0f / glm::vec2(width, height));
 
     m_ssaoPass.resize(width, height);
     m_horizontalBlurPass.resize(width, height);


### PR DESCRIPTION
use texel fetch in blur shaders. it makes semantically more sense and gives a veeeery minor speedup.
