### PR TITLE
Fix name input

### DIFF
--- a/source/logic/menu/items/MenuInput.cpp
+++ b/source/logic/menu/items/MenuInput.cpp
@@ -6,9 +6,9 @@
 #include <rendering/menu/MenuRenderer.h>
 #include <sound/Sound.h>
 
-MenuInput::MenuInput(const QString & label, const QString & placeholder)
+MenuInput::MenuInput(const QString & label, const QString & initialText)
 :   m_label(label)
-,   m_placeholder(placeholder)
+,   m_text(initialText)
 {
 }
 
@@ -62,8 +62,5 @@ const QString & MenuInput::label() const
 
 const QString & MenuInput::text() const
 {
-    if (m_text.isNull()) 
-        return m_placeholder;
-
     return m_text;
 }

--- a/source/logic/menu/items/MenuInput.h
+++ b/source/logic/menu/items/MenuInput.h
@@ -9,7 +9,7 @@ class MenuInput : public MenuItem
 
 public:
     MenuInput(const QString & label,
-              const QString & placeholder);
+              const QString & initialText);
     
     virtual ~MenuInput();
 
@@ -26,7 +26,6 @@ signals:
 
 protected:
     QString m_label;
-    QString m_placeholder;
     QString m_text;
 
 };


### PR DESCRIPTION
this PR only allows digits and letters as input. previously, pressing other buttons resulted in a sound, but not in a visible character, but on hitting backspace you removed this unvisible-character...

i thought digits and letters should be enough.

also, the lastly entered name can be edited as if you just re-entered the name. previously, any keypress (except for enter) would remove the name completely, which was weird imo.
