### PR TITLE
reduce motionblur output buffer size

### DIFF
--- a/data/shaders/motionBlur.frag
+++ b/data/shaders/motionBlur.frag
@@ -15,7 +15,7 @@ uniform float radius;
 uniform int numSamples;
 uniform float currentFPS_targetFPS;
 
-layout (location = 0) out vec4 fragColor;
+layout (location = 0) out vec3 fragColor;
 
 smooth in vec2 v_uv;
 
@@ -96,8 +96,7 @@ void main()
 
     if(radius_neighborhood <= 0.55)
     {
-        fragColor = vec4(resultColor, 1.0);
-        fragColor.w = dot(fragColor.rgb, vec3(0.299, 0.587, 0.114));
+        fragColor = resultColor;
         return;
     }
     // veclocity and its length (radius) of current pixel (sample center)
@@ -158,6 +157,5 @@ void main()
         resultColor += color_sample * coverage_sample;
     }
 
-    fragColor = vec4(resultColor / totalCoverage, 1.0);
-    fragColor.w = dot(fragColor.rgb, vec3(0.299, 0.587, 0.114));
+    fragColor = resultColor / totalCoverage;
 }

--- a/source/rendering/world/postprocessing/MotionBlurPass.cpp
+++ b/source/rendering/world/postprocessing/MotionBlurPass.cpp
@@ -19,7 +19,7 @@ MotionBlurPass::MotionBlurPass()
 :   m_tmVerticalPass("data/shaders/motionBlurTM_vertical.frag", GL_RG16F)
 ,   m_tmHorizontalPass("data/shaders/motionBlurTM_horizontal.frag", GL_RG16F)
 ,   m_neighborMaxPass("data/shaders/motionBlurNM.frag", GL_RG16F)
-, m_blurPass("data/shaders/motionBlur.frag", GL_RGBA32F, GL_LINEAR)
+,   m_blurPass("data/shaders/motionBlur.frag", GL_RGB8, GL_LINEAR)
 {
     initialize();
 }


### PR DESCRIPTION
Hi! I reduced the motion blur output size to GL_RGB8 and removed some unused (?) code from the motionBlur.frag shader. It made things faster for me.
